### PR TITLE
Index Parser v2

### DIFF
--- a/MigrationTools/IndexParser/README.md
+++ b/MigrationTools/IndexParser/README.md
@@ -64,6 +64,7 @@ If your Object Store bucket is not public, you must also specify a credential.  
 3. Execute the function `ora_idx_parser.getSQLIndexes` to get the SQL index definitions. The function takes two input parameters:
    - `collection_name` (varchar2) - the name of the collection to generate indexes for
    - `index_spec` (varchar2) - the MongoDB index definitions.  This may be a JSON array with all the indexes from the index metadata file or a single index definition.
+   - `parallel_idx` (boolean default true) - flag that determines if the tool should use parallel syntax or not, by default it is used
 
 	```
 	-- Pass as an array
@@ -90,9 +91,13 @@ If your Object Store bucket is not public, you must also specify a credential.  
 Example result:
 
 ```
+        alter session enable parallel ddl;
+
 	create index "$ora:shows.summary_1" on shows(
 		json_value(data, '$.summary.stringOnly()' error on error null on empty) asc
-	, 1);
+	, 1) parallel;
+
+        alter session disable parallel ddl;
 
 	/* Execution finished: 1 indexes parsed, 0 failures in collection 'shows' */
 ```

--- a/MigrationTools/IndexParser/ora_idx_parser.body.sql
+++ b/MigrationTools/IndexParser/ora_idx_parser.body.sql
@@ -2,6 +2,7 @@ create or replace package body ora_idx_parser as
   mv_rewrite_number     number := 0;           
   type ktypes           is table of varchar2(1000) index by varchar2(1000);
   type matview_fields   is table of number index by varchar2(1000);
+  type type_count       is table of number index by varchar2(1000);
   type pref_elem        is table of varchar2(1000);
 
   /*
@@ -10,23 +11,17 @@ create or replace package body ora_idx_parser as
    *  PATH  |  TYPE
    *  a     |  object
    */
-  function create_keytypes_map(collection_name varchar)
+  function create_keytypes_map(dguide_arr json_array_t)
   return ktypes
   is
     dg_stmt    clob;
     dataguide  clob;
     path       clob;
     jtype      clob;
-    dguide_arr json_array_t;
     arr_elem   json_object_t;
     key_types  ktypes;
+    count_t    type_count;
   begin
-    dg_stmt := 'select json_dataguide(data)' ||
-               ' from ' || collection_name;
-    execute immediate dg_stmt
-      into dataguide;
-    dguide_arr := json_array_t.parse(dataguide);
-  
     for idx in 0 .. dguide_arr.get_size - 1
     loop
       arr_elem := treat(dguide_arr.get(idx) as json_object_t);
@@ -37,11 +32,37 @@ create or replace package body ora_idx_parser as
       path  := substr(path, 3);
       jtype := arr_elem.get_String('type');
       if (key_types.exists(path)) then
+
+        if (count_t.exists(path)) then
+          count_t(path) := count_t(path) + 1;
+        else 
+          count_t(path) := 2;
+        end if;
+
         key_types(path) := 'multitype';
       else
         key_types(path) := jtype;
       end if;
     end loop;
+
+    for idx in 0 .. dguide_arr.get_size - 1
+    loop
+      arr_elem := treat(dguide_arr.get(idx) as json_object_t);
+      path := arr_elem.get_String('o:path');
+      if (path = '$' or path = '$._id') then
+        continue;
+      end if;
+      path  := substr(path, 3);
+      jtype := arr_elem.get_String('type');
+      if (count_t.exists(path)) then
+        if (count_t(path) = 2 and jtype <> 'array' and key_types.exists(path || '[*]')) then
+          if (jtype = key_types(path || '[*]')) then
+            key_types(path) := 'array';
+          end if;
+        end if;
+      end if;
+    end loop;
+
     return key_types;
   end;
 
@@ -79,11 +100,10 @@ create or replace package body ora_idx_parser as
       for idxk in v_keys.first..v_keys.last 
       loop
         v_key := v_keys(idxk);
-        stmt := 'select regexp_substr(path, ''[^.]+'', 1, level)
-                  from
-                    (select '''|| v_key ||''' path from dual)
-                  connect by level <= length(path)-length(replace(path, ''.''))+1'; 
-                  --'
+        stmt := 'select regexp_substr(path, ''[^.]+'', 1, level) from (select ';
+        stmt := stmt || q'[q'[]' || v_key;
+        stmt := stmt || ']''';
+        stmt := stmt || ' path from dual) connect by level <= length(path)-length(replace(path, ''.''))+1'; 
         path := '';
         open path_cursor for stmt;
         << path_loop >>
@@ -144,11 +164,11 @@ create or replace package body ora_idx_parser as
     for idx in v_keys.first..v_keys.last 
     loop
       v_key := v_keys(idx);
-      stmt := 'select regexp_substr(path, ''[^.]+'', 1, level)
-                  from
-                    (select '''|| v_key ||''' path from dual)
-                  connect by level <= length(path)-length(replace(path, ''.''))+1'; 
-                  --'
+      stmt := 'select regexp_substr(path, ''[^.]+'', 1, level) from (select ';
+      stmt := stmt || q'[q'[]' || v_key;
+      stmt := stmt || ']''';
+      stmt := stmt || ' path from dual) connect by level <= length(path)-length(replace(path, ''.''))+1'; 
+
       path := '$';
       ismatview(path) := 1;
       path := '$.';
@@ -167,18 +187,92 @@ create or replace package body ora_idx_parser as
   end;
 
   /*
+   *  Method that transforms dataguide results from
+   *  hierarchical form to standard form
+   *  {"properties" : a : {...}}. -> [{"$.a": ... }]
+   */
+  procedure translateHierarchicalToStandard(dg_hierarchical json_object_t, path clob, dg in out json_array_t, count_t in out type_count, is_array_type boolean default false)
+  is
+    prop        json_object_t;
+    obj_type    json_object_t;
+    arr_elem    json_object_t;
+    j_tmp_obj   json_object_t;
+    j_item_obj  json_object_t;
+    j_keys      json_key_list;
+    j_arr_type  json_array_t;
+    curr_path   clob;
+    curr_type   clob;
+  begin
+      
+    obj_type := new json_object_t();
+    if (dg_hierarchical.has('type')) and not(is_array_type) then 
+      
+      curr_type := dg_hierarchical.get_String('type');
+
+      if not(count_t.exists(path || '#' || curr_type)) then
+        obj_type.put('o:path', path);
+        obj_type.put('type', curr_type);
+        dg.append(obj_type);
+        count_t(path || '#' || curr_type) := 1;
+      end if;
+    end if;
+
+    if (dg_hierarchical.has('properties')) then
+      prop := dg_hierarchical.get_Object('properties');
+      j_keys := prop.get_keys;
+      for kk in j_keys.first..j_keys.last loop
+        if (j_keys(kk) is null) then
+          continue;
+        end if;
+        j_tmp_obj := prop.get_Object(j_keys(kk));
+        curr_path := path || '.' || j_keys(kk);
+        translateHierarchicalToStandard(j_tmp_obj, curr_path, dg, count_t);
+      end loop;
+
+    end if;
+
+    if (dg_hierarchical.has('oneOf')) then
+      j_arr_type := dg_hierarchical.get_Array('oneOf');
+      for idx in 0 .. j_arr_type.get_size - 1
+      loop
+        arr_elem := treat(j_arr_type.get(idx) as json_object_t);
+        translateHierarchicalToStandard(arr_elem, path, dg, count_t);
+      end loop;
+    end if;  
+
+    if (dg_hierarchical.has('items')) then
+      j_item_obj := dg_hierarchical.get_Object('items');
+
+      if (j_item_obj.has('type')) then
+          curr_type := j_item_obj.get_String('type');
+
+          if not(count_t.exists(path || '[*]' || '#' || curr_type)) then
+            obj_type.put('o:path', path || '[*]' );
+            obj_type.put('type', curr_type);
+            dg.append(obj_type);
+            count_t(path || '[*]' || '#' || curr_type) := 1;
+          end if;
+      end if;
+
+      if (j_item_obj.has('properties')) then
+        translateHierarchicalToStandard(j_item_obj, path, dg, count_t, true);
+      end if;
+    end if;
+  end;
+
+  /*
    *  Method that returns dataguide in hierarchical form
    *  this form is used to build materialized build in a
    *  recursive and simple way
    */
-  function get_dataguide_hierarchical(collection_name varchar)
+  function get_dataguide_hierarchical(collection_name varchar, json_data_column varchar)
   return json_object_t
   is
     dataguide_obj  json_object_t;
     dataguide_clob clob;
     stmt           clob;
   begin
-    stmt := 'select json_dataguide(data, dbms_json.format_hierarchical)' ||
+    stmt := 'select json_dataguide(' || json_data_column || ', dbms_json.format_hierarchical)' ||
              ' from ' || collection_name;
     execute immediate stmt
         into dataguide_clob;
@@ -187,22 +281,46 @@ create or replace package body ora_idx_parser as
   end;
 
   /*
+   *  Method that returns a string with all the double quotes
+   *  inside it with a escape char \
+   *  This avoids problems with paths like 'quot"es'
+   */
+  function escapeKeyChars(p_key clob) return clob
+  is
+    escaped_key clob;
+    stmt        clob;
+  begin
+    stmt := 'select replace('|| 'q''[' || p_key || ']'',  ''"'', ''\"'') from dual';
+    execute immediate stmt into escaped_key;
+
+    return escaped_key;
+  end;
+
+  /*
    *  Method that returns a clob with all the paths used in a materialized view
    *  recursion calls over dataguide are performed, only the paths within mat_paths_idx
    *  are used. Errors are returned through error_msg
    */
-  function generate_matview_paths(prop json_object_t, p_path varchar, mat_paths_idx matview_fields, fullpath varchar, tabs varchar, error_msg in out clob)
+  function generate_matview_paths(prop in out json_object_t, p_path varchar, mat_paths_idx matview_fields, fullpath varchar, 
+                                  tabs varchar, error_msg in out clob, col_count in out number, col_map_mv in out ktypes)
   return clob
   is
     j_obj     json_object_t;
     j_tmp_obj json_object_t;
+    j_obj_tp1 json_object_t;
+    j_obj_tp2 json_object_t;
     j_keys    json_key_list;
-    j_one_of  json_element_t;
+    j_one_of  json_array_t;
     j_type    clob;
     n_stmt    clob;
     tmp_stmt  clob;
     col_name  clob;
+    type_objs clob;
+    type_1    clob;
+    type_2    clob;
+    arr_size  number;
     is_first  boolean;
+    type_err  boolean := true;
   begin 
     
     if (error_msg is not null or prop is null) or not(mat_paths_idx.exists(fullpath)) then
@@ -210,8 +328,44 @@ create or replace package body ora_idx_parser as
     end if;
 
     if (prop.has('oneOf')) then
-      error_msg := '/* Path ' || fullpath || ' cannot have multiple types, found in '; 
-      return null;
+      j_one_of := prop.get_Array('oneOf');
+      arr_size := j_one_of.get_Size();
+      if (arr_size = 2) then
+        j_obj_tp1 := treat(j_one_of.get(0) as json_object_t);
+        j_obj_tp2 := treat(j_one_of.get(1) as json_object_t);
+
+        if (j_obj_tp1.has('type') and j_obj_tp2.has('type')) then
+          type_1 := j_obj_tp1.get_String('type');
+          type_2 := j_obj_tp2.get_String('type');
+          if (type_1 = 'array' and type_2 <> 'array' and type_2 <> 'object') then
+            j_obj_tp1 := treat(j_obj_tp1.get('items') as json_object_t);
+            if (j_obj_tp1.has('type')) then
+              type_1 := j_obj_tp1.get_String('type');
+              if (type_1 = type_2) then
+                type_err := false;
+                prop := treat(j_one_of.get(0) as json_object_t);
+              end if;
+            end if;
+          elsif (type_2 = 'array' and type_1 <> 'array' and type_1 <> 'object') then
+            j_obj_tp2 := treat(j_obj_tp2.get('items') as json_object_t);
+            if (j_obj_tp2.has('type')) then
+              type_2 := j_obj_tp2.get_String('type');
+              if (type_1 = type_2) then
+                type_err := false;
+                prop := treat(j_one_of.get(1) as json_object_t);
+              end if;
+            end if;
+          end if;
+
+          
+        end if;
+      end if;
+
+      if (type_err) then
+        error_msg := '/* Path ' || fullpath || ' cannot have multiple types, found in ';
+        return null;
+      end if;
+      
     end if;
 
     j_type := prop.get_String('type');
@@ -223,7 +377,7 @@ create or replace package body ora_idx_parser as
       is_first := true;
       for kk in j_keys.first..j_keys.last loop
         j_tmp_obj := j_obj.get_Object(j_keys(kk));
-        tmp_stmt := generate_matview_paths(j_tmp_obj, p_path || '.' || j_keys(kk), mat_paths_idx, fullpath || '.' || j_keys(kk), tabs, error_msg);
+        tmp_stmt := generate_matview_paths(j_tmp_obj, p_path || '."' || escapeKeyChars(j_keys(kk)) || '"', mat_paths_idx, fullpath || '.' || j_keys(kk), tabs, error_msg, col_count, col_map_mv);
         if (tmp_stmt is not null) then
           if not(is_first) then
             n_stmt := n_stmt || ', ';
@@ -241,19 +395,29 @@ create or replace package body ora_idx_parser as
         error_msg := '/* Array in path ' || fullpath || ' with mixed types cannot be indexed, found in '; 
         return null;
       end if; 
-        n_stmt := n_stmt || chr(10) || tabs || 'nested path ''' || p_path || '[*]'' ' || chr(10) || tabs || chr(9) || 'columns( ';
-        n_stmt := n_stmt || generate_matview_paths(j_obj, '$', mat_paths_idx,fullpath, tabs || chr(9) || chr(9), error_msg);
+        n_stmt := n_stmt || chr(10) || tabs || 'nested path ' || q'[q'[]' || p_path; 
+        n_stmt := n_stmt || '[*]]'' ' || chr(10) || tabs || chr(9) || 'columns( ';
+        n_stmt := n_stmt || generate_matview_paths(j_obj, '$', mat_paths_idx,fullpath, tabs || chr(9) || chr(9), error_msg, col_count, col_map_mv);
         n_stmt := n_stmt || chr(10) || tabs || chr(9) || ')'; 
     end if;
     
-    col_name := substr(fullpath, 3);
+    col_name := 'col' || col_count;
     col_name := '"' || col_name || '"';
     if (j_type = 'string') then
-      n_stmt := n_stmt || chr(10) || tabs || col_name || ' varchar2 path ''' || p_path || '''';
+      n_stmt := n_stmt || chr(10) || tabs || col_name || ' varchar2 path ' || q'[q'[]' || p_path ;
+      n_stmt := n_stmt || ']'' ';
+      col_map_mv(col_name) := fullpath;
+      col_count := col_count + 1;
     elsif (j_type = 'timestamp') then
-      n_stmt := n_stmt || chr(10) || tabs || col_name || ' timestamp path ''' || p_path || '''';
+      n_stmt := n_stmt || chr(10) || tabs || col_name || ' timestamp path ' || q'[q'[]' || p_path ;
+      n_stmt := n_stmt || ']'' ';
+      col_map_mv(col_name) := fullpath;
+      col_count := col_count + 1;
     elsif (j_type = 'number' or j_type = 'double') then
-      n_stmt := n_stmt || chr(10) || tabs || col_name || ' number path ''' || p_path || '''';
+      n_stmt := n_stmt || chr(10) || tabs || col_name || ' number path ' || q'[q'[]' || p_path ;
+      n_stmt := n_stmt || ']'' ';
+      col_map_mv(col_name) := fullpath;
+      col_count := col_count + 1;
     elsif not(j_type = 'object' or j_type = 'array') then
       error_msg := '/* Type ''' || j_type || ''' in field ''' ||  fullpath || ''' not supported for materialized views, found in '; 
       return null;
@@ -265,13 +429,16 @@ create or replace package body ora_idx_parser as
    *  Method that returns the materialized view SQL
    *  here's the definition and the paths
    */
-  function build_materialized_view(collection_name varchar, mat_paths_idx matview_fields, dataguide_obj json_object_t, error_msg in out clob, err_count in out number)
+  function build_materialized_view(collection_name varchar, mat_paths_idx matview_fields, dataguide_obj json_object_t, 
+                                   error_msg in out clob, err_count in out number, json_data_column varchar2, col_map_mv in out ktypes)
   return clob
   is
     result_output  clob;
     tabs           varchar2(1000) := chr(9) || chr(9);
+    dg             json_object_t;
+    col_count      number := 0;
   begin
-      
+      dg := dataguide_obj;
       result_output := 'create materialized view mv_for_query_rewrite' || mv_rewrite_number || chr(10) || 
              tabs || 'build immediate' || chr(10) ||
              tabs || 'refresh fast on statement with primary key' || chr(10) ||
@@ -279,8 +446,8 @@ create or replace package body ora_idx_parser as
       tabs := tabs || chr(9);
       result_output := result_output || tabs || 'from ' || collection_name || ' col,' || chr(10);
       tabs := tabs || chr(9);
-      result_output := result_output || tabs || 'json_table(col.data, ''$'' error on error null on empty columns(';
-      result_output := result_output || ora_idx_parser.generate_matview_paths(dataguide_obj, '$', mat_paths_idx, '$', tabs || chr(9), error_msg);
+      result_output := result_output || tabs || 'json_table(col.' || json_data_column || ', ''$'' error on error null on empty columns(';
+      result_output := result_output || ora_idx_parser.generate_matview_paths(dg, '$', mat_paths_idx, '$', tabs || chr(9), error_msg, col_count, col_map_mv);
       result_output := result_output || chr(10) || tabs || ')) jt;';
 
       if (error_msg is not null) then
@@ -299,7 +466,7 @@ create or replace package body ora_idx_parser as
    *  a.z is not part of the same path as a.b, hence a parallel array was detected
    */
   function is_valid_index(key_types ktypes, idx_elem json_object_t) 
-  return BOOLEAN
+  return boolean
   is
     path_cursor     sys_refcursor;
     v_idx_keys_obj  json_object_t;
@@ -322,11 +489,11 @@ create or replace package body ora_idx_parser as
       is_other_branch := false;
       v_key := v_idx_keys_list(idx);
 
-      stmt := 'select regexp_substr(path, ''[^.]+'', 1, level)
-                  from
-                    (select '''|| v_key ||''' path from dual)
-                  connect by level <= length(path)-length(replace(path, ''.''))+1'; 
-                  --' 
+      stmt := 'select regexp_substr(path, ''[^.]+'', 1, level) from (select ';
+      stmt := stmt || q'[q'[]' || v_key;
+      stmt := stmt || ']''';
+      stmt := stmt || ' path from dual) connect by level <= length(path)-length(replace(path, ''.''))+1'; 
+      
       key_path := '';
       idx_cursor := 1;
 
@@ -369,12 +536,15 @@ create or replace package body ora_idx_parser as
    *  Method that returns the SQL form of a simple index
    *  i.e. not a TTL or multivalue one
    */
-  function create_regular_idx(collection_name varchar, isunique varchar, idx_name varchar, key_types ktypes, j_keys json_object_t, idx_spec clob, err_count in out number) 
+  function create_regular_idx(collection_name varchar, isunique varchar, idx_name varchar, key_types ktypes, 
+                              j_keys json_object_t, idx_spec clob, err_count in out number, json_data_column varchar2,
+                              parallel_idx boolean) 
   return varchar
   is
     v_keys    json_key_list;
     v_key     clob;
     jtype     clob;
+    order_str     clob;
     out_stmt  clob;
   begin
     out_stmt := 'create ';
@@ -390,9 +560,14 @@ create or replace package body ora_idx_parser as
     for k in v_keys.first..v_keys.last 
     loop
       v_key := v_keys(k);
+
+      order_str := j_keys.get_String(v_key);
      
       jtype := key_types(v_key);
-      out_stmt := out_stmt || chr(10) || chr(9) || 'json_value(data, ''$.' || v_key;
+
+      v_key := escapeKeyChars(v_key);
+      out_stmt := out_stmt || chr(10) || chr(9) || 'json_value(' || json_data_column || ', ' || q'[q'[$."]' || v_key;
+      out_stmt := out_stmt || q'["]';
       case jtype
         when 'string' then
           out_stmt := out_stmt || '.stringOnly()';
@@ -410,12 +585,23 @@ create or replace package body ora_idx_parser as
           err_count := err_count + 1;
           return '/* Unsupported type ''' || jtype || ''', found in ''' || idx_spec || ''' index spec */';
       end case;
-      out_stmt := out_stmt || ''' error on error null on empty) asc';
+      out_stmt := out_stmt || ']'' error on error null on empty)';
+      if (order_str = '-1') then
+        out_stmt := out_stmt || ' desc';
+      else
+        out_stmt := out_stmt || ' asc';
+      end if;
       if (k <> v_keys.last) then
         out_stmt := out_stmt || ', ';
       end if;
     end loop;
-    out_stmt := out_stmt || chr(10) || ', 1);';
+
+    if (parallel_idx) then
+      out_stmt := out_stmt || chr(10) || ', 1) parallel;';
+    else
+      out_stmt := out_stmt || chr(10) || ', 1);';
+    end if;
+    
     return out_stmt;
   end;
 
@@ -434,7 +620,7 @@ create or replace package body ora_idx_parser as
   begin
     out_stmt := 'declare' || chr(10) || chr(9) || 'col SODA_COLLECTION_T;' || chr(10) || chr(9) || 
                 'status number;' || chr(10) || 'begin' || chr(10) || chr(9) || 'col := dbms_soda.open_collection('''|| 
-                collection_name || ''');' || chr(10) || chr(9) || 'status := col.create_index(''{"name" : "$ora:' || collection_name || 
+                collection_name || ''');' || chr(10) || chr(9) || 'status := col.create_index(q''[{"name" : "$ora:' || collection_name || 
                 '.' || idx_name || '", "ttl" : ' || ttl || ', "fields" : [' ;
     
     v_keys :=  j_keys.get_keys;
@@ -450,7 +636,7 @@ create or replace package body ora_idx_parser as
         return '/* TTL indexes only supports datetime type, found in ''' || idx_spec || ''' index spec */';
       end if;
 
-      out_stmt := out_stmt || '{"path" : "' || v_key || '", "datatype": "' || jtype || '"}';
+      out_stmt := out_stmt || '{"path" : "' || escapeKeyChars(v_key) || '", "datatype": "' || jtype || '"}';
 
       if (k <> v_keys.last) then
         out_stmt := out_stmt || ', ';
@@ -462,7 +648,7 @@ create or replace package body ora_idx_parser as
         err_count := err_count + 1;
         return '/* TTL indexes apply to only one single "timestamp" field , found in ''' || idx_spec || ''' index spec */';
     end if;
-    out_stmt := out_stmt || ']}'');' || chr(10) || 'end;' || chr(10) || '/';
+    out_stmt := out_stmt || ']}]'');' || chr(10) || 'end;' || chr(10) || '/';
     return out_stmt;
   end;
 
@@ -470,27 +656,48 @@ create or replace package body ora_idx_parser as
    *  Method that returns the SQL statement to create an index in a
    *  materialized view. This only happens if we have a multivalue one
    */
-  function create_matview_idx(collection_name varchar, idx_name varchar,  j_keys json_object_t) 
+  function create_matview_idx(collection_name varchar, idx_name varchar,  j_keys json_object_t, col_map_mv ktypes, parallel_idx boolean) 
   return varchar
   is
     v_keys    json_key_list;
     v_key     clob;
     jtype     clob;
     out_stmt  clob;
+    order_str clob;
+    key_str   clob;
+    col_count number := 0;
   begin
     out_stmt := 'create index "$ora:' || collection_name || '.' || idx_name || '" on mv_for_query_rewrite' || mv_rewrite_number || '(';
     
     v_keys :=  j_keys.get_keys;
     for k in v_keys.first..v_keys.last 
     loop
-      v_key := v_keys(k);
-      v_key := '"' || v_key || '"';
+      v_key := '"' || 'col' || col_count || '"';
+      key_str := col_map_mv(v_key);
+      key_str := substr(key_str, 3);
+
+      order_str := j_keys.get_String(key_str);
+
+      col_count := col_count + 1;
       out_stmt := out_stmt || v_key;
+
+      if (order_str = '-1') then
+        out_stmt := out_stmt || ' desc';
+      else
+        out_stmt := out_stmt || ' asc';
+      end if;
+
       if (k <> v_keys.last) then
         out_stmt := out_stmt || ', ';
       end if;
     end loop;
-    out_stmt := out_stmt || ');';
+    
+    if (parallel_idx) then
+      out_stmt := out_stmt || ') parallel;';
+    else
+      out_stmt := out_stmt || ');';
+    end if;
+
     return out_stmt;
   end;
 
@@ -507,30 +714,67 @@ create or replace package body ora_idx_parser as
     return  chr(10) || chr(10) || '/* Execution finished: ' || successful_idx || ' indexes parsed, ' || err_count || ' failures in collection ''' ||  collection_name || ''' */';
   end; 
 
+  /*
+   *  Method that gets the json data column name from collection metadata
+   *  data column name could not be the same for some collections
+   */
+  function getDataColumnName(collection_name varchar2) return clob
+  is
+    col_name  clob;
+    stmt      clob;
+  begin
+    stmt := 'select json_value(json_descriptor, ''$.contentColumn.name'') from user_soda_collections 
+             where uri_name = ''' || collection_name || ''' fetch first 1 rows only';
+    execute immediate stmt
+        into col_name;
+    return col_name;
+  end;
+
+  /*
+   *  Method that gets the DB object name from collection metadata
+   *  Collection name could not be the same as table/view name
+   */
+  function getObjectName(collection_name varchar2) return clob
+  is
+    obj_name  clob;
+    stmt      clob;
+  begin
+    stmt := 'select object_name from user_soda_collections 
+             where uri_name = ''' || collection_name || ''' fetch first 1 rows only';
+    execute immediate stmt
+        into obj_name;
+    return obj_name;
+  end;
+
   /* 
    * Method that returns a clob with the json indexes parsed in SQL form
    * requires the collection name and the json with indexes specs
    */
-  function getSQLIndexes(collection_name varchar2, index_spec varchar2) return clob
+  function getSQLIndexes(collection_name varchar2, index_spec varchar2, parallel_idx boolean default true) return clob
   is
-    key_types       ktypes;
-    all_mat_paths   matview_fields;
-    mat_paths_idx   matview_fields;
-    idx_spec_elem   json_element_t;
-    idx_spec        json_array_t;
-    arr_elem        json_object_t;
-    dg_hierarchical json_object_t;
-    v_idx_keys_obj  json_object_t;
-    v_idx_keys_list json_key_list;
-    v_key           clob;
-    v_name          clob;
-    v_unique        clob;
-    v_exp           clob;
-    final_output    clob;
-    error_msg       clob;
-    err_count       number := 0;
-    is_mat_idx      boolean;
-    is_valid_idx    boolean := true;
+    key_types        ktypes;
+    col_map_mv       ktypes;
+    all_mat_paths    matview_fields;
+    mat_paths_idx    matview_fields;
+    idx_spec_elem    json_element_t;
+    idx_spec         json_array_t;
+    dguide_arr       json_array_t;
+    arr_elem         json_object_t;
+    dg_hierarchical  json_object_t;
+    v_idx_keys_obj   json_object_t;
+    v_idx_keys_list  json_key_list;
+    v_key            clob;
+    v_name           clob;
+    v_unique         clob;
+    v_exp            clob;
+    obj_name         clob;
+    final_output     clob;
+    error_msg        clob;
+    json_data_column clob;
+    err_count        number := 0;
+    is_mat_idx       boolean;
+    is_valid_idx     boolean := true;
+    count_t          type_count;
   begin
     -- Set Correct Format
     idx_spec_elem := json_element_t.parse(index_spec);
@@ -539,15 +783,28 @@ create or replace package body ora_idx_parser as
     else 
       idx_spec := Treat(idx_spec_elem as json_array_t); 
     end if;
+
+    -- Get object name
+    obj_name := getObjectName(collection_name);
+
+    -- Get Json Data Column name
+    json_data_column := getDataColumnName(collection_name);
+
+    -- Get Dataguide in hierarchical form
+    dg_hierarchical := get_dataguide_hierarchical(obj_name, json_data_column);
     
+    -- Transform dataguide hierarchical into a standar
+    dguide_arr := new json_array_t();
+    translateHierarchicalToStandard(dg_hierarchical, '$', dguide_arr, count_t);
+
     -- Get a map(path, type)
-    key_types := create_keytypes_map(collection_name);
+    key_types := create_keytypes_map(dguide_arr);
     -- Get a map(path, number)
     all_mat_paths := create_matview_paths_map(idx_spec, key_types);
-    
-    -- Get Dataguide in hierarchical form in case a materialized view is required
-    if (all_mat_paths.count() > 0) then
-      dg_hierarchical := get_dataguide_hierarchical(collection_name);
+
+    -- Add syntax to allow index parallel creation
+    if (parallel_idx) then
+      final_output := 'alter session enable parallel ddl;';
     end if;
 
     -- Build Indexes
@@ -630,18 +887,23 @@ create or replace package body ora_idx_parser as
       if (v_exp is not null) then
         final_output := final_output || create_ttl_idx(collection_name, v_name, v_exp, key_types, v_idx_keys_obj, arr_elem.stringify, err_count);
       elsif (is_mat_idx) then
-        final_output := final_output || build_materialized_view(collection_name, mat_paths_idx, dg_hierarchical, error_msg, err_count);
+        final_output := final_output || build_materialized_view(obj_name, mat_paths_idx, dg_hierarchical, error_msg, err_count, json_data_column, col_map_mv);
         if (error_msg is not null) then
           error_msg := null;
           final_output := final_output || '''' || arr_elem.stringify() || ''' index spec */' ;
         else
-          final_output := final_output || chr(10) || chr(10) || create_matview_idx(collection_name,v_name, v_idx_keys_obj);
+          final_output := final_output || chr(10) || chr(10) || create_matview_idx(obj_name,v_name, v_idx_keys_obj, col_map_mv, parallel_idx);
           mv_rewrite_number := mv_rewrite_number + 1;
         end if;
       else
-        final_output := final_output || create_regular_idx(collection_name, v_unique, v_name, key_types, v_idx_keys_obj, arr_elem.stringify, err_count);
+        final_output := final_output || create_regular_idx(obj_name, v_unique, v_name, key_types, v_idx_keys_obj, arr_elem.stringify, err_count, json_data_column, parallel_idx);
       end if;
     end loop;
+
+    -- Add syntax to allow index parallel creation
+    if (parallel_idx) then
+      final_output := final_output || chr(10) || chr(10) || 'alter session disable parallel ddl;';
+    end if;
 
     final_output := final_output || generateSummary(collection_name, err_count,  idx_spec.get_size);
     

--- a/MigrationTools/IndexParser/ora_idx_parser.sql
+++ b/MigrationTools/IndexParser/ora_idx_parser.sql
@@ -1,8 +1,8 @@
-create or replace package ora_idx_parser as 
+create or replace package ora_idx_parser authid current_user as 
    /* 
     * Method that returns a clob with the json indexes parsed in SQL form
     * requires the collection name and the json with indexes specs
     */
-   function getSQLIndexes(collection_name varchar2, index_spec varchar2) return clob;
+   function getSQLIndexes(collection_name varchar2, index_spec varchar2, parallel_idx boolean default true) return clob;
 end ora_idx_parser; 
 /


### PR DESCRIPTION
-> Json column now its selected from soda metadata
-> New parameter: Now user can send a boolean so the tool add parallel index creation syntax
-> Handle the case of keys using double or single quotes i.e. "quot'e" or "quot\"e"
-> Dataguide is only called once, translation from hierarchical to standard 
-> Column names for materialized views are not the path anymore, because if the path name is longer that 128 chars, execution fail 
-> Tool now accepts order in the index creation (desc and asc) 
-> Tool now handles the case of indexing an scalar and array of the same type