### PR TITLE
Fixed typo in word 'timestamps'

### DIFF
--- a/YCSB/ycsb-soda/core/src/main/java/com/yahoo/ycsb/workloads/TimeSeriesWorkload.java
+++ b/YCSB/ycsb-soda/core/src/main/java/com/yahoo/ycsb/workloads/TimeSeriesWorkload.java
@@ -274,7 +274,7 @@ import com.yahoo.ycsb.measurements.Measurements;
  * 60 seconds.</li>
  * <li>Support random time series cardinality. Right now every series has the same 
  * cardinality.</li>
- * <li>Truly random timetamps per time series. We could use bitmaps to determine if
+ * <li>Truly random timestamp per time series. We could use bitmaps to determine if
  * a series has had a value written for a given timestamp. Right now all of the series
  * are in sync time-wise.</li>
  * <li>Possibly a real-time load where values are written with the current system time.

--- a/YCSB/ycsb-soda/core/src/main/java/site/ycsb/workloads/TimeSeriesWorkload.java
+++ b/YCSB/ycsb-soda/core/src/main/java/site/ycsb/workloads/TimeSeriesWorkload.java
@@ -274,7 +274,7 @@ import site.ycsb.measurements.Measurements;
  * 60 seconds.</li>
  * <li>Support random time series cardinality. Right now every series has the same 
  * cardinality.</li>
- * <li>Truly random timetamps per time series. We could use bitmaps to determine if
+ * <li>Truly random timestamp per time series. We could use bitmaps to determine if
  * a series has had a value written for a given timestamp. Right now all of the series
  * are in sync time-wise.</li>
  * <li>Possibly a real-time load where values are written with the current system time.


### PR DESCRIPTION
While using this code, I encountered a typo in the files :
`YCSB/ycsb-soda/core/src/main/java/com/yahoo/ycsb/workloads/TimeSeriesWorkload.java`
`YCSB/ycsb-soda/core/src/main/java/site/ycsb/workloads/TimeSeriesWorkload.java`

The word `'timetamps'` was incorrectly used instead of `'timestamp'`. I have corrected this typo and opened a pull request referencing the corresponding issue number.